### PR TITLE
Retrieving the metadata from local json files rather than using the C…

### DIFF
--- a/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/CSW/CSWGetRecordsReader.js
+++ b/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/CSW/CSWGetRecordsReader.js
@@ -1,3 +1,8 @@
+/*
+ * Currently retrieving this information from json files using the MetatdataRecordsStore.
+ * Leaving this in in case we want to revert.
+ */
+
 Ext.ns("GDP");
 
 GDP.CSWGetRecordsReader = function(meta, recordType) {
@@ -15,7 +20,7 @@ GDP.CSWGetRecordsReader = function(meta, recordType) {
             {name: "wms", type: "string"},
             {name: "sos", type: "string"},
             {name: "fieldLabels"},
-            {name: "helptext"} 
+            {name: "helptext"}
         ]
         );
     }
@@ -47,7 +52,7 @@ Ext.extend(GDP.CSWGetRecordsReader, Ext.data.DataReader, {
         }
         return this.readRecords(data);
     },
-    
+
 
     /** private: method[readRecords]
      *  :param data: ``DOMElement | String | Object`` A document element or XHR
@@ -57,14 +62,14 @@ Ext.extend(GDP.CSWGetRecordsReader, Ext.data.DataReader, {
      *      capabilities parser.
      *  :return: ``Object`` A data block which is used by an ``Ext.data.Store``
      *      as a cache of ``Ext.data.Record`` objects.
-     *  
+     *
      *  Create a data block containing Ext.data.Records from an XML document.
      */
     readRecords: function(data) {
         if(typeof data === "string" || data.nodeType) {
             data = this.meta.format.read(data);
         }
-        
+
         var records = [];
 
         Ext.iterate(data.records, function (item) {
@@ -73,9 +78,9 @@ Ext.extend(GDP.CSWGetRecordsReader, Ext.data.DataReader, {
             values.derivatives = [];
             values.scenarios = [];
             values.gcms = [];
-            
+
             var idInfos = item.identificationInfo;
-            
+
             Ext.iterate(idInfos, function (idInfo) {
                 var keywordTypes = idInfo.descriptiveKeywords;
                 var srvId = idInfo.serviceIdentification;
@@ -87,7 +92,7 @@ Ext.extend(GDP.CSWGetRecordsReader, Ext.data.DataReader, {
                     // means not json, set abstract to null
                     abstrakt = null;
                 }
-                
+
                 if (keywordTypes) {
                     Ext.iterate(keywordTypes, function (kt) {
                         if (kt.type.codeListValue === "derivative") {
@@ -140,18 +145,18 @@ Ext.extend(GDP.CSWGetRecordsReader, Ext.data.DataReader, {
                         else if (serviceId === "OGC-SOS") {
                             values.sos = endpoint;
                         }
-                    } 
+                    }
                 }
                 if (abstrakt !== null) {
                     values.fieldLabels = abstrakt.fieldlabels;
                     values.helptext = abstrakt.helptext;
                 }
-                
+
             }, this);
-            
+
             records.push(new this.recordType(values));
         }, this);
-        
+
         return {
             totalRecords: records.length,
             success: true,

--- a/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/CSW/CSWGetRecordsStore.js
+++ b/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/CSW/CSWGetRecordsStore.js
@@ -1,8 +1,13 @@
+/*
+ * Currently retrieving this information from json files using the MetatdataRecordsStore.
+ * Leaving this in in case we want to revert.
+ */
+
 Ext.ns("GDP");
 
 GDP.CSWGetRecordsStore = function(meta) {
     meta = meta || {};
-    
+
     meta.format = new OpenLayers.Format.CSWGetRecords(meta.opts);
     meta.format.write();
     meta.fields = [

--- a/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/LayerController.js
+++ b/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/LayerController.js
@@ -2,7 +2,7 @@ Ext.ns("GDP");
 
 GDP.LayerController = Ext.extend(Ext.util.Observable, {
     MAXIMUM_DIMENSION_COUNT : 101,
-    CSW_ERROR_MSG : 'Could not access CSW catalog. Application will not be functional.  Either reload the application or contact system administrator.',
+    METADATA_SERVICE_ERROR_MSG : 'Could not access application metadata service. Application will not be functional.  Either reload the application or contact system administrator.',
     WMS_ERROR_MSG : 'Could not access WMS endpoint. Application will not be functional.  Either reload the application or contact system administrator.',
     SOS_ERROR_MSG : 'Could not access SOS endpoint. Application will not be functional.  Either reload the application or contact system administrator.',
     baseLayer : undefined,
@@ -122,7 +122,7 @@ GDP.LayerController = Ext.extend(Ext.util.Observable, {
             "changeopacity",
             "drewbbox",
             "exception-capstore",
-            "exception-catstore",
+            "exception-metadatastore",
             "exception-sosstore",
             "loaded-capstore",
             "loaded-catstore",
@@ -280,7 +280,7 @@ GDP.LayerController = Ext.extend(Ext.util.Observable, {
         store.removeAll();
         var extents = record.get('dimensions')[extentName];
         if (extents) {
-            
+
             var timesToLoad = [];
             var cleanedTimes = [];
             Ext.each(extents.values, function (item, index, allItems){
@@ -363,12 +363,12 @@ GDP.LayerController = Ext.extend(Ext.util.Observable, {
         this.fireEvent('exception-capstore', args);
     },
     getRecordsExceptionOccurred : function (args) {
-        LOG.debug('LayerController:getRecordsExceptionFired: Firing event "exception-catstore"');
+        LOG.debug('LayerController:getRecordsExceptionFired: Firing event "exception-metadatastore"');
         if (LOADMASK) LOADMASK.hide();
         NOTIFY.error({
-            msg : this.CSW_ERROR_MSG
+            msg : this.METADATA_SERVICE_ERROR_MSG
         });
-        this.fireEvent('exception-catstore', args);
+        this.fireEvent('exception-metadatastore', args);
     },
     sosExceptionOccurred : function (args) {
         LOG.debug('LayerController:sosExceptionFired: Firing event "exception-sosstore"');
@@ -384,7 +384,7 @@ GDP.LayerController = Ext.extend(Ext.util.Observable, {
     },
     updatePlotter : function () {
         LOG.debug('LayerController:updatePlotter: Firing event "updateplotter"');
-        this.fireEvent('updateplotter', 
+        this.fireEvent('updateplotter',
             {
                 // need to get this from csw record
                 url : this.getSOSEndpoint(),

--- a/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/metadata/MetadataRecordsReader.js
+++ b/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/metadata/MetadataRecordsReader.js
@@ -1,0 +1,128 @@
+/*
+ * Application now reads metadata information from json files rather than a CSW call.
+ * Kept the record store structure to limit the changes needed in the rest of the application
+ */
+
+Ext.ns("GDP");
+
+GDP.MetadataRecordsReader = function(meta, recordType) {
+    meta = meta || {};
+
+    if(typeof recordType !== "function") {
+        recordType = Ext.data.Record.create(meta.fields || [
+            {name: "identifier", type: "string"},
+            {name: "derivatives"}, // Array of objects
+            {name: "scenarios"}, // Array of objects
+            {name: "gcms"}, // Array of objects
+            {name: "opendap", type: "string"},
+            {name: "wms", type: "string"},
+            {name: "sos", type: "string"},
+            {name: "fieldLabels"},
+            {name: "helptext"}
+        ]
+        );
+    }
+    GDP.MetadataRecordsReader.superclass.constructor.call(
+        this, meta, recordType
+    );
+};
+
+Ext.extend(GDP.MetadataRecordsReader, Ext.data.DataReader, {
+
+    /** private: method[read]
+     *  @param request: ``Object`` The XHR object which contains the json string
+     *
+     *  @return: ``Object`` A data block which is used by an ``Ext.data.Store``
+     *      as a cache of ``Ext.data.Record`` objects.
+     */
+    read: function(request) {
+        var data = Ext.util.JSON.decode(request.responseText);
+        return this.readRecords(data);
+    },
+
+
+    /** private: method[readRecords]
+     *  @param data: json Object
+     *  @return: ``Object`` A data block which is used by an ``Ext.data.Store``
+     *      as a cache of ``Ext.data.Record`` objects.
+     *
+     *  Create a data block containing Ext.data.Records from a json object.
+     */
+    readRecords: function(data) {
+        if(typeof data === "string" || data.nodeType) {
+            data = this.meta.format.read(data);
+        }
+
+        var records = [];
+
+        Ext.iterate(data, function (item) {
+            var values = {};
+            values.identifier = item.identifier;
+            values.derivatives = [];
+            values.scenarios = [];
+            values.gcms = [];
+
+			var keywordTypes = item.descriptiveKeywords;
+			var srvId = item.serviceIdentification;
+			var abstrakt = item.hasOwnProperty('abstract') ? item["abstract"] : null;
+
+			if (keywordTypes) {
+				if (keywordTypes.hasOwnProperty('derivatives')) {
+					Ext.iterate(keywordTypes.derivatives, function(key) {
+						var derivArr = [];
+						derivArr.push(key);
+						if (abstrakt !== null) {
+							derivArr.push(abstrakt.quicktips.derivatives[key]);
+						}
+						values.derivatives.push(derivArr);
+					}, this);
+				}
+				if (keywordTypes.hasOwnProperty('scenarios')) {
+					Ext.iterate(keywordTypes.scenarios, function(key) {
+						var scenarioArr = [];
+						scenarioArr.push(key);
+						if (abstrakt !== null) {
+							scenarioArr.push(abstrakt.quicktips.scenarios[key]);
+						}
+						values.scenarios.push(scenarioArr);
+					}, this);
+				}
+				if (keywordTypes.hasOwnProperty('gcm')) {
+					Ext.iterate(keywordTypes.gcm, function(key) {
+						var gcmArr = [];
+						gcmArr.push(key);
+						if (abstrakt !== null) {
+							gcmArr.push(abstrakt.quicktips.gcms[key]);
+						}
+						values.gcms.push(gcmArr);
+					}, this);
+				}
+			}
+			if (srvId) {
+				if (srvId.hasOwnProperty('sos')) {
+					values.sos = srvId.sos;
+				}
+				if (srvId.hasOwnProperty('opendap')) {
+					values.opendap = srvId.opendap;
+				}
+				if (srvId.hasOwnProperty('wms')) {
+					values.wms = srvId.wms;
+				}
+			}
+			if (abstrakt !== null) {
+				values.fieldLabels = abstrakt.fieldlabels;
+				values.helptext = abstrakt.helptext;
+			}
+            records.push(new this.recordType(values));
+        }, this);
+
+        return {
+            totalRecords: records.length,
+            success: true,
+            records: records
+        };
+
+    }
+
+});
+

--- a/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/metadata/MetadataRecordsStore.js
+++ b/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/metadata/MetadataRecordsStore.js
@@ -1,0 +1,33 @@
+/*
+ * Application now reads metadata information from json files rather than a CSW call.
+ * Kept the record store structure to limit the changes needed in the rest of the application
+ */
+
+Ext.ns("GDP");
+
+GDP.MetadataRecordsStore = function(meta) {
+    meta = meta || {};
+
+    meta.fields = [
+        {name: "identifier", type: "string"},
+        {name: "derivatives"}, // Array of objects
+        {name: "scenarios"}, // Array of objects
+        {name: "gcms"}, // Array of objects
+        {name: "opendap", type: "string"},
+        {name: "wms", type: "string"},
+        {name: "sos", type: "string"},
+        {name: "fieldLabels"},
+        {name: "helptext"}
+    ]
+    GDP.MetadataRecordsStore.superclass.constructor.call(
+        this,
+        Ext.apply(meta, {
+            proxy: meta.proxy || (!meta.data ? new Ext.data.HttpProxy({url: meta.url, disableCaching: false, method: "GET"}) : undefined),
+            baseParams : meta.opts,
+            reader: new GDP.MetadataRecordsReader(meta)
+        })
+    );
+};
+
+Ext.extend(GDP.MetadataRecordsStore, Ext.data.Store);
+

--- a/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/panels/BaseMap.js
+++ b/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/panels/BaseMap.js
@@ -309,7 +309,7 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
                     var tooltipTopPosition = Ext.ComponentMgr.get('plotFieldSet').getPosition()[1] + Ext.ComponentMgr.get('plotFieldSet').getHeight() + 5;
                     Ext.ux.NotifyMgr.offsets = [tooltipTopPosition, 10];
 
-                    // TODO - There should be a better way of getting at this. 
+                    // TODO - There should be a better way of getting at this.
                     // Look into OpenLayers scoping for layer.on events
                     if (!Ext.ComponentMgr.get('mapPanel').notificationWindow) {
                         Ext.ComponentMgr.get('mapPanel').notificationWindow = new Ext.ux.Notify({
@@ -401,7 +401,7 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
 
 				this.map.addLayers([selectedLayer]);
 
-                // TODO - There should be a better way of getting at this. 
+                // TODO - There should be a better way of getting at this.
                 // Look into OpenLayers scoping for layer.on events
                 if (Ext.ComponentMgr.get('mapPanel').notificationWindow) {
                     Ext.ComponentMgr.get('mapPanel').notificationWindow.animHide();
@@ -416,7 +416,7 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
             this.map.addControl(selectorControl);
             selectorControl.activate();
         }, this);
-        this.layerController.on('exception-catstore', function () {}, this);
+        this.layerController.on('exception-metadatastore', function () {}, this);
         this.on('resize', function () {
             this.realignLegend();
         }, this);
@@ -506,16 +506,16 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
             return null;
         }
     },
-    clearLayers : function () { 
+    clearLayers : function () {
         LOG.debug('BaseMap:clearLayers: Handling request.');
         Ext.each(this.layers.data.getRange(), function (item){
             var layer = item.data.layer;
             if (layer.isBaseLayer || layer.CLASS_NAME === 'OpenLayers.Layer.Vector' || layer.name === 'foilayer') {
                 LOG.debug('BaseMap:clearLayers: Layer '+layer.id+' is a base layer and will not be cleared.');
                 return;
-            }                
-            //TODO- This remove function should just take the layer defined above but 
-            // testing shows the layer store does not remove the layer using the 
+            }
+            //TODO- This remove function should just take the layer defined above but
+            // testing shows the layer store does not remove the layer using the
             // one defined above but this does work.
             this.layers.remove(this.layers.getById(layer.id));
             LOG.debug('BaseMap:clearLayers: Cleared layer: ' + layer.id);
@@ -524,7 +524,7 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
     },
     onChangeLayer : function () {
         LOG.debug('BaseMap:onChangeLayer: Handling request.');
-            
+
         var layer = this.layerController.getLayer();
 
         if (!this.currentLayer || this.currentLayer.getLayer() !== layer) {
@@ -559,12 +559,12 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
             LOG.debug(' BaseMap:onChangeDimension: Found existing layer index ' + result);
             return result;
         }, this, 0);
-		
+
         var params = {};
         Ext.apply(params, this.layerController.getAllDimensions());
-		
+
         this.replaceLayer(
-            this.layerController.getLayer(), 
+            this.layerController.getLayer(),
             params,
             (-1 < existingLayerIndex) ? existingLayerIndex : undefined
             );
@@ -573,13 +573,13 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
     onChangeLegend : function () {
         LOG.debug('BaseMap:onChangeLegend: Handling Request.');
         if (!this.layerController.getLayer()) return;
-        
+
         var legendHref = this.layerController.getLegendRecord().data.href;
         if(this.legendImage.url && this.legendImage.url.contains(legendHref)) {
             LOG.debug('BaseMap: \'changelegend\' called but legend image is already the same as requested legend.');
             return;
         }
-        
+
         LOG.debug('BaseMap: Removing current legend image and reapplying new legend image.');
         this.legendImage.setUrl(GDP.PROXY_PREFIX + legendHref);
         var record = this.layerController.getLegendRecord();
@@ -605,14 +605,14 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
             LOG.debug('BaseMap:onReplaceBaseLayer: A record object was not passed in. Using map\'s baselayer.');
             record = this.layerController.getBaseLayer();
         }
-            
+
         var baseLayerIndex = 0;
         if (this.layers.getCount() > 0) {
             LOG.debug('BaseMap:onReplaceBaseLayer: Trying to find current base layer to remove it.');
             baseLayerIndex = this.layers.findBy(function (r, id){
                 return r.data.layer.isBaseLayer;
             });
-                
+
             if (baseLayerIndex > -1 ) {
                 this.layers.removeAt(baseLayerIndex);
                 LOG.debug('BaseMap:onReplaceBaseLayer: Removed base layer from this object\'s map.layers at index ' + baseLayerIndex);
@@ -621,24 +621,24 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
                 LOG.debug('BaseMap:onReplaceBaseLayer: Base layer not found.');
             }
         }
-            
+
         this.layers.add([record]);
         //        this.redraw();
         LOG.debug('BaseMap:onReplaceBaseLayer: Added base layer to this object\'s map.layers at index ' + baseLayerIndex);
-    },    
+    },
     replaceLayer : function (record, params, existingIndex) {
         LOG.debug('BaseMap:replaceLayer: Handling request.');
         if (!record) return;
         if (!params) {
             params = {};
         }
-		
+
         if (this.currentLayer) {
             var layer = this.currentLayer.getLayer();
             layer.setOpacity(0.0); // This will effectively hide the current layer
             LOG.debug('BaseMap:replaceLayer: Hiding current layer');
         }
-                
+
         if (existingIndex) {
             LOG.debug('BaseMap:replaceLayer: Replacing current layer with already-existing layer at index ' + existingIndex);
             var existingLayer = this.layers.getAt(existingIndex);
@@ -653,7 +653,7 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
                 transparent : true,
                 styles : (params.styles) ? params.styles : this.layerController.getLegendRecord().id
             }, params);
-            
+
 
             copy.get('layer').displayInLayerSwitcher = false;
             copy.get('layer').mergeNewParams(params);
@@ -663,7 +663,7 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
                 //                if (LOADMASK) LOADMASK.hide();
                 });
             this.layers.add(copy);
-            
+
             var foilayer = this.map.getLayersByName('foilayer');
             var selectedLayer = this.map.getLayersByName('selectedlayer');
             var highestZ = this.getHighestZIndex();
@@ -673,9 +673,9 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
             if (selectedLayer.length) {
                 selectedLayer[0].setZIndex(highestZ + 2);
             }
-            
+
         }
-        
+
     },
     createGeomOverlay : function (args) {
         LOG.debug('BaseMap:createGeometryOverlay: Drawing vector');
@@ -684,7 +684,7 @@ GDP.BaseMap = Ext.extend(GeoExt.MapPanel, {
         var feature = new OpenLayers.Feature.Vector(geom, {
             id : 'draw-vector'
         });
-            
+
         this.map.getLayersByName('bboxvector')[0].removeAllFeatures(null,true);
         this.map.getLayersByName('bboxvector')[0].addFeatures([feature]);
         this.map.zoomToExtent(bounds,true);

--- a/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/panels/Plotter.js
+++ b/gdp-derivative-ui/src/main/webapp/js/derivative_portal/components/panels/Plotter.js
@@ -78,7 +78,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
             LOG.debug('Plotter:onLoadedCatstore');
             this.onLoadedLeafstore(args);
         }, this);
-        this.controller.on('exception-catstore', function () {
+        this.controller.on('exception-metadatastore', function () {
             this.collapse();
         }, this);
         this.on('resize', function () {
@@ -106,7 +106,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
 		Ext.get(this.plotterDiv).dom.innerHTML = '';
         var height = Math.round(0.5 * parseInt(Ext.get(this.plotterDiv).dom.style.height));
         LOADMASK = new Ext.LoadMask(Ext.get(this.plotterDiv).dom, {
-            msg: '<div id="cida-load-msg">Loading...</div><img height="' + height + '" src="images/cida-anim.gif" />', 
+            msg: '<div id="cida-load-msg">Loading...</div><img height="' + height + '" src="images/cida-anim.gif" />',
             msgCls: 'cida-load-plotter'
         });
         LOADMASK.show();
@@ -138,7 +138,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
 						sequencePosition : 1,
 						pressed : this.visibility[1],
 						enableToggle: true
-					}), 
+					}),
 					new Ext.Button({
 						text : 'a1b',
 						id : 'plotter-toolbar-btngrp-table3',
@@ -180,12 +180,12 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
         this.topToolbar["plotter-toolbar-errorbars-button"].on('click', function (obj) {
             this.graph.updateOptions({
                 fillAlpha : obj.pressed ? 0.15 : 0.0
-                
+
             });
             this.errorBarsOn = obj.pressed;
-        }, this);          
+        }, this);
         this.topToolbar.doLayout();
-        
+
         Ext.iterate(this.scenarioGcmJSON, function (scenario, object) {
             Ext.iterate(object, function (gcm) {
                 if (gcm !== 'ensemble') {
@@ -204,11 +204,11 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
         }, this);
         this.resizePlotter();
     },
-	
+
 	/**
-	 * Using the leaf store, test whether or not it contains a scenario and 
+	 * Using the leaf store, test whether or not it contains a scenario and
 	 * whether or not that scenario contains a given gcm
-	 * 
+	 *
 	 * @argument {Object} args "store" - {Object} The leaf store, "scenario" - {String} , "gcm" - {String}
 	 */
 	testScenarioGCMComboExists : function (args) {
@@ -216,7 +216,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
 		var store = args.store;
 		var scenario = args.scenario;
 		var gcm = args.gcm;
-		
+
 		var scenarioGCMComboExists = false;
 
 		// This should always be true, unless we selectively don't have scenarios
@@ -227,18 +227,18 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
 			}, this);
 			scenarioGCMComboExists = gcmArray.indexOf(gcm.toLowerCase()) > -1;
 		}
-		
+
 		return scenarioGCMComboExists;
 	},
-	
+
     resizePlotter : function () {
         LOG.debug('Plotter:resizePlotter()');
         var divPlotter = Ext.get(this.plotterDiv);
         var divLegend = Ext.get(this.legendDiv);
-        
+
         divLegend.setWidth(this.legendWidth);
         divPlotter.setWidth(this.getWidth() - (this.legendWidth + 2));
-        divPlotter.setHeight(this.getHeight() - this.toolbar.getHeight()); 
+        divPlotter.setHeight(this.getHeight() - this.toolbar.getHeight());
         if (this.graph) {
             this.graph.resize(divPlotter.getWidth(), divPlotter.getHeight());
         }
@@ -257,20 +257,20 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
                 }
             }, this);
         }, this);
-		
+
         // Set up the text for the initial view of the plotter panel
         Ext.DomHelper.append(Ext.DomQuery.selectNode("div[id='dygraph-content']"), {
-            tag : 'div', 
-            id : 'plotter-prefill-text',
+            tag : 'div',
+           id : 'plotter-prefill-text',
             html : args.record.get('helptext')['plotWindowIntroText']
-        });
-        
+		});
+
         this.doLayout();
-        
+
         // This tooltip will show up to the right of any title text
         this.titleTipText = '&nbsp;&nbsp;<span ext:qtip="'+args.record.get('helptext')['plotHelp']+'" class="x-combo-list-item"><img class="quicktip-img" src="images/info.gif" /></span>';
     },
-	
+
 	onLoadedLeafstore : function (args) {
 		this.scenarioGcmJSON = this.cloneScenarioGcmJSON();
 		this.leafStore = args.store;
@@ -291,16 +291,16 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
 			}
         }, this);
 	},
-	
+
     loadSOSStore : function (meta, offering) {
         var url = "proxy/" + meta.url + "?service=SOS&request=GetObservation&version=1.0.0&offering=" + encodeURIComponent(encodeURIComponent(offering)) + "&observedProperty=mean";
-        
+
         this.sosStore.push(new GDP.SOSGetObservationStore({
             url : url, // gmlid is url for now, eventually, use SOS endpoint + gmlid or whatever param
             autoLoad : true,
             proxy : new Ext.data.HttpProxy({
-                url: url, 
-                disableCaching: false, 
+                url: url,
+                disableCaching: false,
                 method: "GET"
             }),
             baseParams : {},
@@ -318,7 +318,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
                 },
                 scope: this
             }
-            
+
         }));
     },
     globalArrayUpdate : function (store, meta) {
@@ -373,12 +373,12 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
                     }
                 });
             });
-            
+
             this.yLabels = scenarios;
-            
+
             this.plotterYMin = 1000000;
             this.plotterYMax = 0;
-            
+
             for (var i=0; i<observationsLength; i++) {
                 this.plotterData.push(new Array());
                 this.plotterData[i][0] = this.scenarioGcmJSON[scenarios[0]][gcms[0]][i][0];
@@ -403,9 +403,9 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
                 }, this);
             }
             this.dygraphUpdateOptions(store);
-            
+
             // Set up the download CSV button
-            this.topToolbar["plotter-toolbar-download-button"].un('click');          
+            this.topToolbar["plotter-toolbar-download-button"].un('click');
             this.topToolbar["plotter-toolbar-download-button"].on('click', function (){
                 var id = Ext.id();
                 var frame = document.createElement('iframe');
@@ -445,7 +445,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
                                 }
                             });
                         });
-                    
+
                         var csv = '#' + scope.plotterTitle + ' calculated by ' + window.location + '\n';
                         var line = 'date, ';
                         Ext.each(scenarios, function (scenario) {
@@ -456,7 +456,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
                             }, this);
                         }, this);
                         csv += line.substr(0, line.length - 1) + "\n";
-                        
+
                         for (var i=0; i<observationsLength; i++) {
                             var line2 = '';
                             line2 += scope.scenarioGcmJSON[scenarios[0]][gcms[0]][i][0].getFullYear() + ",";
@@ -473,7 +473,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
 
                         return encodeURIComponent(csv);
                     }(this)
-                }); 
+                });
 
                 document.body.appendChild(form);
                 var callback = function (e) {
@@ -498,12 +498,12 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
                 Ext.EventManager.on(frame, Ext.isIE?'readystatechange':'load', callback);
                 form.submit();
             }, this);
-            
+
         }
     },
     dygraphUpdateOptions : function (store) {
         var record = store.getAt(0);
-        
+
         // this is mean for us, probably figure this out better?
         var yaxisUnits = record.get('dataRecord')[1].uom;
 
@@ -526,7 +526,7 @@ GDP.Plotter = Ext.extend(Ext.Panel, {
                 },
                 rightGap : 5,
                 showRangeSelector: true,
-                //ylabel: record.data.dataRecord[1].name,                            
+                //ylabel: record.data.dataRecord[1].name,
                 yAxisLabelWidth: 75,
                 ylabel: this.controller.getDerivative().get('derivative') + " " + this.controller.getThreshold() + " " + this.controller.getUnits().replace('deg', '&deg;'),
                 valueRange: [this.plotterYMin - (this.plotterYMin / 10) , this.plotterYMax + (this.plotterYMax / 10)],

--- a/gdp-derivative-ui/src/main/webapp/js/derivative_portal/root.js
+++ b/gdp-derivative-ui/src/main/webapp/js/derivative_portal/root.js
@@ -4,14 +4,14 @@ var LOADMASK;
 
 if (Ext.isIE) { // http://www.mail-archive.com/users@openlayers.org/msg01838.html
     document.namespaces;
-} 
+}
 
 Ext.onReady(function () {
     initializeLogging();
     initializeNotification();
     initializeMapping();
     initializeQuickTips();
-	
+
 	// Add the correct URL to the footer
 	document.getElementById('footer-url-info').innerHTML = 'URL: ' + document.location.href;
 });
@@ -21,11 +21,11 @@ Ext.onReady(function () {
  */
 function initializeLogging() {
     LOG = log4javascript.getLogger();
-    
+
     var layout = new log4javascript.PatternLayout(GDP.LOG4JS_PATTERN_LAYOUT);
-    
+
     var appender = new log4javascript.BrowserConsoleAppender();
-    
+
     appender.setLayout(layout);
     //    Thresholds:
     //    log4javascript.Level.ALL
@@ -37,42 +37,42 @@ function initializeLogging() {
     //    log4javascript.Level.FATAL
     //    log4javascript.Level.OFF
     appender.setThreshold(log4javascript.Level.ALL);
-    
+
     LOG.addAppender(appender);
-    
+
     LOG.info('Derivative Portal: Log4javascript v.'+log4javascript.version+' initialized.');
 }
 
 /**
- * Usage example : 
+ * Usage example :
  *      NOTIFY.error({
  *          msg : 'Message here'
  *      });
  */
 function initializeNotification() {
     LOG.info('Derivative Portal: Initializing Notification.');
-    
+
     var defaultConfig = {
         msgWidth: 400,
         hideDelay: 8000
     };
-    
+
     /**
      * ERROR
      */
     var _notifyError = function (args) {
         LOG.trace('Derivative Portal: Showing error popup');
         var config = args || {};
-	
+
         var moreInfo = new Ext.Button({
             text: 'More Info...'
         });
-        
+
         var buttons = [];
         if (config.moreInfoAction) {
             buttons.push(moreInfo);
         }
-        
+
         var notifyError = new Ext.ux.Notify(Ext.applyIf({
             title: 'Error!',
             titleIconCls: 'titleicon-error',
@@ -80,17 +80,17 @@ function initializeNotification() {
             msg: config.msg || 'An error has occured.',
             buttons: buttons
         }, defaultConfig));
-		
+
         if (config.moreInfoAction) {
             moreInfo.on('click', function() {
                 notifyError.hide();
                 config.moreInfoAction();
             });
         }
-		
+
         notifyError.show(document);
     };
-	
+
     /**
      * SUCCESS
      */
@@ -102,10 +102,10 @@ function initializeNotification() {
             msg: msg.msg || 'Data saved successfully.'
         }, defaultConfig)).show(document);
     };
-	
+
     /**
      * DEBUG NOTIFY
-     */    
+     */
     var _notifyDebug = function (msg) {
         LOG.debug('Derivative Portal: Showing debug popup');
         new Ext.ux.Notify(Ext.applyIf({
@@ -114,7 +114,7 @@ function initializeNotification() {
             msg: msg.msg || ''
         }, defaultConfig)).show(document);
     };
-    
+
     /**
      * WARNING
      */
@@ -126,7 +126,7 @@ function initializeNotification() {
             msg: msg.msg || ''
         }, defaultConfig)).show(document);
     };
-    
+
     /**
      * INFO
      */
@@ -137,8 +137,8 @@ function initializeNotification() {
             titleIconCls: 'titleicon-info',
             msg: msg.msg || ''
         }, defaultConfig)).show(document);
-    };    
-    
+    };
+
     NOTIFY = {
         debug : _notifyDebug,
         success : _notifySuccess,
@@ -146,49 +146,49 @@ function initializeNotification() {
         warn : _notifyWarning,
         info : _notifyInfo
     };
-    
+
     LOG.info('Derivative Portal: Notification Initialized.');
 }
 
 function initializeMapping() {
     LOG.info('Derivative Portal: Initializing Mapping.');
-	
+
     LOG.debug('Derivative Portal:initializeMapping: Constructing endpoint panel.');
     var legendStore = new Ext.data.JsonStore({
         idProperty: 'name',
         root: 'styles',
         fields: [
         {
-            name: 'name', 
+            name: 'name',
             mapping: 'name'
         },
         {
-            name: 'title', 
+            name: 'title',
             mapping: 'title'
         },
         {
-            name: 'abstrakt', 
+            name: 'abstrakt',
             mapping: 'abstract'
         },
         {
-            name: 'width', 
+            name: 'width',
             mapping: 'legend.width'
         },
         {
-            name: 'height', 
+            name: 'height',
             mapping: 'legend.height'
         },
         {
-            name: 'format', 
+            name: 'format',
             mapping: 'legend.format'
         },
         {
-            name: 'href', 
+            name: 'href',
             mapping: 'legend.href'
         }
         ]
     });
-    
+
     var baseLayerStore = new GeoExt.data.LayerStore({
         layers : [
         new OpenLayers.Layer.XYZ(
@@ -236,7 +236,7 @@ function initializeMapping() {
         legendStore : legendStore,
         dimensions : ['time', 'elevation']
     });
-    
+
     var mapPanel = new GDP.BaseMap({
         id : 'mapPanel',
         region: 'center',
@@ -247,18 +247,18 @@ function initializeMapping() {
     });
 
     layerController.requestBaseLayer(layerController.getBaseLayer());
-    
+
     var capabilitiesStore = new GeoExt.data.WMSCapabilitiesStore({
         url : GDP.WMS_URL,
         storeId : 'capabilitiesStore'
     });
-    
+
     /*
      * Documenting this, because this is very much a convention, close to a hack
-     * Parent record is a starting point, the id is all we need to enter a 
-     * "CSW tree".
-     * 
-     * The "CSW tree" needs to have the following dynamics
+     * Parent record is a starting point to enter a
+     * "Metadata tree".
+     *
+     * The "Metadata tree" needs to have the following dynamics
      * - Parent record enumerates keywords of all children, broken into categories
      * - Children only contain the keywords that describe data in their branch
      * - The leaf record contains both a data endpoint and wms endpoint (sos?)
@@ -267,28 +267,12 @@ function initializeMapping() {
      * - Keywords are used to build the UI, which then are used to get to the
      *   map layer or data
      */
-    var getRecordsStore = new GDP.CSWGetRecordsStore({
-        url : "geonetwork/csw",
-        storeId : 'cswStore',
-        opts : {
-            resultType : 'results',
-            outputSchema : 'http://www.isotc211.org/2005/gmd',
-            Query : {
-                ElementSetName : {
-                    value: 'full'
-                },
-                Constraint : {
-                    Filter : {
-                        type : '==',
-                        property : 'identifier',
-                        value : GDP.CSW_QUERY_CONSTRAINT_FILTER_VALUE
-                    },
-                    version : '1.1.0'
-                }
-            }
-        }
+    var getRecordsStore = new GDP.MetadataRecordsStore({
+        url : "json/parent.json",
+        storeId : 'metadataStore',
+        opts : {}
     });
-    
+
     var configPanel = new GDP.DatasetConfigPanel({
         controller : layerController,
         collapsible : true,
@@ -310,17 +294,17 @@ function initializeMapping() {
         height : 200,
         controller : layerController
     });
-    
+
     var centerPanel = new Ext.Panel({
         id : 'center-panel',
         region : 'center',
         layout : 'border',
         items : [ mapPanel, plotterPanel]
     });
-    
+
     LOG.info('Derivative Portal: Mapping initialized.');
     LOADMASK = new Ext.LoadMask(Ext.getBody(), {
-        msg: '<div id="cida-load-msg">Loading...</div><img src="images/cida-anim.gif" />', 
+        msg: '<div id="cida-load-msg">Loading...</div><img src="images/cida-anim.gif" />',
         msgCls: 'cida-load'
     });
     LOADMASK.show();
@@ -343,10 +327,10 @@ function initializeMapping() {
     });
     var viewPort = new Ext.Viewport({
         renderTo : document.body,
-        items : [headerPanel, centerPanel, configPanel, footerPanel], 
+        items : [headerPanel, centerPanel, configPanel, footerPanel],
         layout: 'border'
     });
-    
+
     layerController.on('application-resize', function(collapse){
         LOG.debug('Root:Observed "application-resize": Expand: ' + collapse);
         if (collapse) {
@@ -373,7 +357,7 @@ function initializeQuickTips() {
 }
 
 // This is here just for shortcutting some processes in order to test stuff like XML parsing
-function test() { 
+function test() {
     var testArray = [2, 3, 4, 5];
     LOG.debug(Array.max(testArray, 2));
     LOG.debug(Array.max(testArray, 11));

--- a/gdp-derivative-ui/src/main/webapp/json/cooling_degree_days.json
+++ b/gdp-derivative-ui/src/main/webapp/json/cooling_degree_days.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "cooling_degree_days",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Cooling Degree Days"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"HADCM3",
+				"GFDL 2.1"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_cooling_degree_days,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/cooling_degree_days_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/cooling_degree_days_scenarios.json
@@ -1,0 +1,71 @@
+[
+	{
+		"identifier" : "cooling_degree_days_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_cooling_degree_days"
+		}
+	},{
+		"identifier" : "cooling_degree_days_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_cooling_degree_days"
+		} 
+	},{
+		"identifier" : "cooling_degree_days_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_cooling_degree_days"
+		}	
+	}, {
+		"identifier" : "cooling_degree_days_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_cooling_degree_days"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/days_with_precip_above.json
+++ b/gdp-derivative-ui/src/main/webapp/json/days_with_precip_above.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "days_with_precip_above",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Days with Precip Above"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"HADCM3",
+				"GFDL 2.1"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_pr-days_above_threshold,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/days_with_precip_above_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/days_with_precip_above_scenarios.json
@@ -1,0 +1,68 @@
+[
+	{
+		"identifier" : "days_with_precip_above_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_prcp_abv"
+		}
+	},{
+		"identifier" : "days_with_precip_above_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_prcp_abv"
+		} 
+	},{
+		"identifier" : "days_with_precip_above_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_prcp_abv"
+		}	
+	}, {
+		"identifier" : "days_with_precip_above_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_prcp_abv"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/days_with_tmax_above.json
+++ b/gdp-derivative-ui/src/main/webapp/json/days_with_tmax_above.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "days_with_tmax_above",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Days with Tmax Above"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_tmax-days_above_threshold,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/days_with_tmax_above_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/days_with_tmax_above_scenarios.json
@@ -1,0 +1,71 @@
+[
+	{
+		"identifier" : "days_with_tmax_above_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_tmax"
+		}
+	},{
+		"identifier" : "days_with_tmax_above_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_tmax"
+		} 
+	},{
+		"identifier" : "days_with_tmax_above_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_tmax"
+		}	
+	}, {
+		"identifier" : "days_with_tmax_above_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_tmax"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/days_with_tmin_below.json
+++ b/gdp-derivative-ui/src/main/webapp/json/days_with_tmin_below.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "days_with_tmax_above",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Days with Tmin Below"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"HADCM3",
+				"GFDL 2.1"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_tmin-days_below_threshold,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/days_with_tmin_below_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/days_with_tmin_below_scenarios.json
@@ -1,0 +1,71 @@
+[
+	{
+		"identifier" : "days_with_tmin_below_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_tmin"
+		}
+	},{
+		"identifier" : "days_with_tmin_below_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_tmin"
+		} 
+	},{
+		"identifier" : "days_with_tmin_below_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_tmin"
+		}	
+	}, {
+		"identifier" : "days_with_tmin_below_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_tmin"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/growing_degree_days.json
+++ b/gdp-derivative-ui/src/main/webapp/json/growing_degree_days.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "growing_degree_days",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Growing Degree Days"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"HADCM3",
+				"GFDL 2.1"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_growing_degree_days,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/growing_degree_days_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/growing_degree_days_scenarios.json
@@ -1,0 +1,71 @@
+[
+	{
+		"identifier" : "growing_degree_days_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_growing_degree_days"
+		}
+	},{
+		"identifier" : "growing_degree_days_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_growing_degree_days"
+		} 
+	},{
+		"identifier" : "growing_degree_days_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_growing_degree_days"
+		}	
+	}, {
+		"identifier" : "growing_degree_days_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : ">http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_growing_degree_days"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/growing_season_length.json
+++ b/gdp-derivative-ui/src/main/webapp/json/growing_season_length.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "growing_season_length",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Growing Season Length"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"HADCM3",
+				"GFDL 2.1"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_growing_season_length,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/growing_season_length_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/growing_season_length_scenarios.json
@@ -1,0 +1,71 @@
+[
+	{
+		"identifier" : "growing_season_length_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_growing_season_length"
+		}
+	},{
+		"identifier" : "growing_season_length_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_growing_season_length"
+		} 
+	},{
+		"identifier" : "growing_season_length_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_growing_season_length"
+		}	
+	}, {
+		"identifier" : "growing_season_length_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_growing_season_length"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/heating_degree_days.json
+++ b/gdp-derivative-ui/src/main/webapp/json/heating_degree_days.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "heating_degree_days",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Heating Degree Days"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"HADCM3",
+				"GFDL 2.1"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_heating_degree_days,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/heating_degree_days_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/heating_degree_days_scenarios.json
@@ -1,0 +1,71 @@
+[
+	{
+		"identifier" : "heating_degree_days_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_heating_degree_days"
+		}
+	},{
+		"identifier" : "heating_degree_days_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_heating_degree_days"
+		} 
+	},{
+		"identifier" : "heating_degree_days_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_heating_degree_days"
+		}	
+	}, {
+		"identifier" : "heating_degree_days_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_heating_degree_days"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/longest_run_with_precip_below.json
+++ b/gdp-derivative-ui/src/main/webapp/json/longest_run_with_precip_below.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "longest_run_with_precip_below",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Longest Run with Precip Below"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"HADCM3",
+				"GFDL 2.1"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_pr-spell_length_below_threshold,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/longest_run_with_precip_below_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/longest_run_with_precip_below_scenarios.json
@@ -1,0 +1,68 @@
+[
+	{
+		"identifier" : "longest_run_with_precip_below_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_run_prcp_blw"
+		}
+	},{
+		"identifier" : "longest_run_with_precip_below_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_run_prcp_blw"
+		} 
+	},{
+		"identifier" : "longest_run_with_precip_below_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_run_prcp_blw"
+		}	
+	}, {
+		"identifier" : "longest_run_with_precip_below_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_run_prcp_blw"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/longest_run_with_tmax_above.json
+++ b/gdp-derivative-ui/src/main/webapp/json/longest_run_with_tmax_above.json
@@ -1,0 +1,26 @@
+[
+	{
+		"identifier" : "longest_run_with_tmax_above",
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Longest Run with Tmax Above"
+			],
+			"scenarios" : [
+				"A2",
+				"A1FI",
+				"A1B",
+				"B2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"HADCM3",
+				"GFDL 2.1"
+			]
+		},
+		"serviceIdentification" : {
+			"sos" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/thredds/sos/dcp/{shapefile}/{gcm}_{scenario}_tmax-spell_length_above_threshold,{threshold},dsg.nc"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/longest_run_with_tmax_above_scenarios.json
+++ b/gdp-derivative-ui/src/main/webapp/json/longest_run_with_tmax_above_scenarios.json
@@ -1,0 +1,71 @@
+[
+	{
+		"identifier" : "longest_run_with_tmax_above_a1fI",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1FI"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1fi_tmax_spell"
+		}
+	},{
+		"identifier" : "longest_run_with_tmax_above_a1b",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A1B"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a1b_tmax_spell"
+		} 
+	},{
+		"identifier" : "longest_run_with_tmax_above_a2",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"A2"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=a2_tmax_spell"
+		}	
+	}, {
+		"identifier" : "longest_run_with_tmax_above_b1",
+		"descriptiveKeywords" : {
+			"scenarios" : [
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"HADCM3",
+				"GFDL 2.1",
+				"CCSM3"
+			]
+		},
+		"serviceIdentification" : {
+			"wms" : "http://cida-eros-derivativeprod.er.usgs.gov:8080/ncWMS/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1&DATASET=b1_tmax_spell"
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/json/parent.json
+++ b/gdp-derivative-ui/src/main/webapp/json/parent.json
@@ -1,0 +1,106 @@
+[
+	{
+		"identifier" : "3722c5a9-0247-47d0-b566-36a99579c48d",
+		"abstract" : {
+			"quicktips" : {
+
+			"derivatives" : {
+
+			"Days with Precip Above" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. Annual days with a projected cumulative precipitation above a threshold are represented on the original 1/8th degree grid. Precalculated thresholds are: 1, 2, 3, 4 inches.",
+
+			"Longest Run with Tmax Above" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. Longest run of days in one year with a projected maximum temperature above a temperature threshold are represented on the original 1/8th degree grid. Precalculated thresholds are: 90, 95, and 100 degrees Fahrenheit.",
+
+			"Longest Run with Precip Below" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. Longest run of days in a year with projected precipitation below a threshold are represented on the original 1/8th degree grid. Precalculated thresholds are: 3 mm.",
+
+			"Days with Tmax Above" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. Annual days with a projected maximum temperature above a temperature threshold are represented on the original 1/8th degree grid. Precalculated thresholds are: 90, 95, and 100 degrees Fahrenheit.",
+
+			"Days with Tmin Below" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. Annual days with a projected minimum temperature below a temperature threshold are represented on the original 1/8th degree grid. Precalculated thresholds are: 0, 10, 32 degrees Fahrenheit.",
+
+			"Growing Degree Days" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. Growing degree days is represented on the original 1/8th degree grid. Precalculated threshold is: 50 degrees Fahrenheit",
+
+			"Heating Degree Days" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. heating degree days is represented on the original 1/8th degree grid. Precalculated threshold is: 65 degrees Fahrenheit",
+
+			"Cooling Degree Days" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. Cooling degree days are represented on the original 1/8th degree grid. Precalculated threshold is: 65 degrees Fahrenheit.",
+
+			"Growing Season Length" : "This is a derivative data product produced from a 1/8th degree daily downscaled climate projection dataset. Growing season length is represented on the original 1/8th degree grid. Precalculated threshold is: 32 degrees Fahrenheit."
+
+			},
+
+			"scenarios" : {
+
+			"A1FI" : "Very High: The A1FI scenario describes a future world of very rapid globalization and economic growth with Fossil Intensive (FI) energy sources. The A1FI scenario is displayed by default because it most closely matches the current trajectory of population and emissions growth.",
+
+			"A2" : "High: The A2 scenario describes a very heterogeneous world. Economic development is primarily regionally oriented and per capita economic growth is slower than other scenarios.",
+
+			"A1B" : "Medium: The A1B scenario describes a future world of very rapid globalization and economic growth with a Balanced (B) use of energy sources.",
+
+			"B1" : "Low: The B1 scenario describes a future world of very rapic globalization rapid change in economic structures toward the introduction of clean and resource-efficient technologies."
+
+			},
+
+			"gcms" : {
+
+			"Ensemble" : "An ensemble average of PCM, CCSM3, GFDL 2.1, and HADCM3 climate models.",
+
+			"PCM" : "National Center for Atmospheric Research, USA",
+
+			"CCSM3" : "National Center for Atmospheric Research, USA",
+
+			"GFDL 2.1" : "US Dept. of Commerce / NOAA / Geophysical Fluid Dynamics Laboratory, USA",
+
+			"HADCM3" : "Hadley Center, UK"
+
+			}
+
+			},
+
+			"fieldlabels" : {
+
+			"derivative" : "Choose the derivative you are interested in mapping and plotting.",
+
+			"scenario" : "Choose a scenario. A scenario is a coherent, internally consistent and plausible description of a possible future state of the world. It is not a forecast; rather, each scenario is one alternative image of how the future can unfold. A projection may serve as the raw material for a scenario, but scenarios often require additional information (e.g., about baseline conditions). A set of scenarios is often adopted to reflect, as well as possible, the range of uncertainty in projections. Other terms that have been used as synonyms for scenario are \"characterization\", \"storyline\" and \"construction\".",
+
+			"gcm" : "Choose a Climate Model.",
+
+			"timeperiod" : "Choose a Time Period."
+
+			},
+
+			"helptext" : {
+
+			"plotWindowIntroText" : "This web portal allows visualization and downloading of future climate projections from a group of 'statistically downscaled' global climate models (GCMs). Temperature and precipitation projections from these models have been used to calculate derivative climate indicators that measure the number of days that exceed certain thresholds. You can control what is shown on the map and this plot window using the toolbar on the left.<br><br>All derivative climate indicators on this page have been derived from a suite of downscaled <a href=\"http://www-pcmdi.llnl.gov/ipcc/about_ipcc.php\" target=\"_blank\"> World Climate Research Program Coupled Model Inter-comparison Project 3</a> atmospheric-oceanic general circulation model simulations using four scenarios from the <a href=\"http://sedac.ciesin.columbia.edu/ddc/sres/\" target=\"_blank\">International Panel on Climate Change Special Report on Emissions Scenarios.</a><br><br>The current downscaled data used to derive the indices available in the portal were provided by Hayhoe, Stoner, and Yang. <a href=\"http://cida.usgs.gov/thredds/catalog.html?dataset=cida.usgs.gov/thredds/dcp/conus\" target=\"_blank\">Documentation summarizing this dataset can be found here.</a><br><br><a href=\"http://dx.doi.org/10.1002/joc.3603\" target=\"_blank\">A peer reviewed journal publication summarizing the data used in this application is available here.</a><br><br>Spatial statistics of these derivatives were calculated using the  <a href=\"https://my.usgs.gov/confluence/display/GeoDataPortal/GDP+Home\" target=\"_blank\">USGS Geo Data Portal</a> Feature Weighted Grid Statistics Algorithm. <a href=\"http://pubs.usgs.gov/of/2011/1157/pdf/ofr2011-1157.pdf\" target=\"_blank\">Description and testing of this web processing service algorithm is available here.</a><br><br>Although this program has been used by the U.S. Geological Survey (USGS), no warranty, expressed or implied, is made by the USGS or the U.S. Government as to the accuracy and functioning of the program and related program material nor shall the fact of distribution constitute any such warranty, and no responsibility is assumed by the USGS in connection therewith.<br>",
+
+			"plotHelp" : "This plot displays annual time series of the selected derivative climate indicator. Each scenario is summarized using a solid line to represent a climate model ensemble average and a shaded envelope representing the minimum and maximum values indicated by the suite of climate models used to generate the ensemble. You can zoom in and pan through the plot using the left and right handles and by dragging the selected time period below the plot. Data used to generate this plot is available at the Download button on the right.",
+
+			"changeProdText" : "When this is enabled, the map shows the change for a given time period against the historic period (1961-1990)"
+
+			}	
+		},
+		"descriptiveKeywords" : {
+			"derivatives" : [
+				"Days with Tmax Above",
+				"Days with Tmin Below",
+				"Days with Precip Above",
+				"Longest Run with Tmax Above",
+				"Longest Run with Precip Below",
+				"Growing Degree Days",
+				"Heating Degree Days",
+				"Cooling Degree Days",
+				"Growing Season Length"
+			],
+			"scenarios" : [
+				"A1FI",
+				"A2",
+				"A1B",
+				"B1"
+			],
+			"gcm" : [
+				"Ensemble",
+				"PCM",
+				"CCSM3",
+				"GFDL 2.1",
+				"HADCM3"
+			]
+		}
+	}
+]

--- a/gdp-derivative-ui/src/main/webapp/template/scripts.jsp
+++ b/gdp-derivative-ui/src/main/webapp/template/scripts.jsp
@@ -52,8 +52,8 @@
 <%-- Extended Openlayers/GeoExt readers/writers --%>
 <script type="text/javascript" src='openlayers/extensions/format/csw/v2_0_2.js'></script>
 <script type="text/javascript" src='openlayers/extensions/format/sos/SOSGetObservation.js'></script>
-<script type="text/javascript" src='${param["ComponentDir"]}/CSW/CSWGetRecordsStore.js'></script>
-<script type="text/javascript" src='${param["ComponentDir"]}/CSW/CSWGetRecordsReader.js'></script>
+<script type="text/javascript" src='${param["ComponentDir"]}/metadata/MetadataRecordsStore.js'></script>
+<script type="text/javascript" src='${param["ComponentDir"]}/metadata/MetadataRecordsReader.js'></script>
 <script type="text/javascript" src='${param["ComponentDir"]}/SOS/SOSGetObservationStore.js'></script>
 <script type="text/javascript" src='${param["ComponentDir"]}/SOS/SOSGetObservationReader.js'></script>
 


### PR DESCRIPTION
…SW service. I made no changes to the way the records are stored and instead modified the reader to process a json file rather than the CSW XML.

The json is organized so that there is a parent.json file containing the information that the app needs to initialize. Each derivative has two files. For example for Days With Tmax Above, there is a days_with_tmax_above.json and days_with_tmax_above_scenarios.json. This mimics the separate calls to the CSW for these pieces of information. I have only created files for Days With Tmax Above and Days with Tmin Below. The rest will follow once the format has been approved.

The files are read using the new files MetadataRecordsStore and MetadataRecordsReader. I have left in the CSWGetRecordsStore and CSWGetRecordsReader even though they are no longer included in the app. I thought it might be valuable to have them hang around for awhile.